### PR TITLE
get_average_drift sanity check function in processors

### DIFF
--- a/smol/moca/processor.py
+++ b/smol/moca/processor.py
@@ -232,6 +232,47 @@ class CEProcessor(BaseProcessor):
         return [species[i] for i, species in
                 zip(enc_occu, self.allowed_species)]
 
+    def get_average_drift(self, iterations=5000):
+        """Get the average forward and reverse drift for the given property.
+
+        This is a sanity check function. The drift value should be very, very,
+        very small, the smaller the better...think machine precision values.
+
+        The average drift is the difference between the quick routine for used
+        for MC to get a property difference from a single flip and the
+        change in that property from explicitly calculating it fully for the
+        initial state and the flipped state.
+
+        Args:
+            iterations (int): optional
+                number of iterations/flips to compute.
+
+        Returns:
+            tuple: (float, float) forward and reverse average property drift
+        """
+        forward_drift, reverse_drift = 0.0, 0.0
+        trajectory = []
+        occu = [np.random.choice(species) for species in self.allowed_species]
+        occu = self.encode_occupancy(occu)
+        for _ in range(iterations):
+            site = np.random.randint(self.size)
+            species = set(range(len(self.allowed_species[site])))-{occu[site]}
+            species = np.random.choice(list(species))
+            delta_prop = self.compute_property_change(occu, [(site, species)])
+            new_occu = occu.copy()
+            new_occu[site] = species
+            prop = self.compute_property(occu)
+            new_prop = self.compute_property(new_occu)
+            forward_drift += (new_prop - prop) - delta_prop
+            reverse_flips = [(site, occu[site])]
+            trajectory.append((prop - new_prop, new_occu, reverse_flips))
+            occu = new_occu
+
+        forward_drift /= iterations
+        reverse_drift = sum(dp - self.compute_property_change(o, f)
+                            for dp, o, f in trajectory) / iterations
+        return forward_drift, reverse_drift
+
     def _delta_corr(self, flips, occu):
         """
         Compute the change in the correlation vector from a list of flips.


### PR DESCRIPTION
## Summary
Implemented a function to check the drift in a computed property for use in monte carlo. This addresses #56. 

* `CEProcessor.get_average_drift` function to calculate the amount of forward and reverse drift for a set amount of iterations.

## Checklist


- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.

