### PR TITLE
sorting coef indices during pruning to ensure correct order

### DIFF
--- a/smol/cofe/expansion.py
+++ b/smol/cofe/expansion.py
@@ -155,9 +155,10 @@ class ClusterExpansion(MSONable):
                    if abs(coef) < threshold]
         self.cluster_subspace.remove_orbit_bit_combos(bit_ids)
         # Update necessary attributes
-        ids_compliment = list(set(range(len(self.coefs))) - set(bit_ids))
-        self.coefs = self.coefs[ids_compliment]
-        self._feat_matrix = self._feat_matrix[:, ids_compliment]
+        ids_complement = list(set(range(len(self.coefs))) - set(bit_ids))
+        ids_complement.sort()
+        self.coefs = self.coefs[ids_complement]
+        self._feat_matrix = self._feat_matrix[:, ids_complement]
         self._eci = None  # Reset
 
     # This needs further testing. For out-of-training structures


### PR DESCRIPTION
## Summary

In prune function, added a call to sort the list after the sets of all ECI ids and ECIs below threshold were subtracted. Previously, my ECI were out of order after pruning due to sets not being ordered, ex: my Ewald ECI was the 70th term in my coefficient list out of 142 ECI; as a result, the energies of a structure before and after pruning were very different. This should fix that.

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Tests have been added for any new functionality or bug fixes. (No new functionality)
- [ ] All existing tests pass.

Looks like there are some errors in the tests with the processor related to the use of delta_ewald_single_flip(), which takes 7 positional arguments and only gives 6 and an error related to the StructureWrangler feature matrix. I'll create the pull request anyway, but I'm not quite sure how to fix those errors, especially they're not quite related to the change I made.

The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
