### PR TITLE
Unit-tests and modifications to filtering by duplicate corr vectors

### DIFF
--- a/tests/test_cofe/test_wrangler.py
+++ b/tests/test_cofe/test_wrangler.py
@@ -1,5 +1,7 @@
 import unittest
 import json
+from copy import deepcopy
+
 import numpy as np
 from smol.cofe import (StructureWrangler, ClusterSubspace,
                        weights_energy_above_hull,
@@ -193,6 +195,31 @@ class TestStructureWrangler(unittest.TestCase):
                          len_total - len_filtered)
         self.assertEqual(self.sw.metadata['applied_filters'][0]['Ewald']['nstructs_total'],
                          len_total)
+
+    def test_get_duplicate_corr_inds(self):
+        ind = np.random.randint(self.sw.num_structures)
+        dup_item = deepcopy(self.sw.data_items[ind])
+        self.sw.data_items.append(dup_item)
+        self.assertEqual(self.sw.get_duplicate_corr_inds(),
+                         [[ind, self.sw.num_structures - 1]])
+
+    def test_filter_duplicate_corrs(self):
+        dup_items = []
+        for i in range(4):
+            ind = np.random.randint(self.sw.num_structures)
+            dup_item = deepcopy(self.sw.data_items[ind])
+            dup_item['properties']['energy'] = np.inf
+            dup_items.append(dup_item)
+
+        n_before = self.sw.num_structures
+        self.sw._items += dup_items
+
+        self.assertEqual(self.sw.num_structures, n_before + len(dup_items))
+        self.assertTrue(np.inf in self.sw.get_property_vector('energy'))
+        self.sw.filter_duplicate_corrs('energy')
+        print(self.sw.num_structures)
+        self.assertEqual(self.sw.num_structures, n_before)
+        self.assertTrue(np.inf not in self.sw.get_property_vector('energy'))
 
     def test_msonable(self):
         self.sw.metadata['key'] = 4


### PR DESCRIPTION
## Summary

Slight modifications to #67. The filtering is now done automatically such that structures with duplicate corrs and higher (or lower) energy are removed under the hood with `filter_duplicate_corrs`.

Unit-tests implemented for both `filter_duplicate_corrs` and `get_duplicate_corr_inds`.

## Checklist

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
