### PR TITLE
Overlap canonical

### DIFF
--- a/smol/moca/ensembles/canonical.py
+++ b/smol/moca/ensembles/canonical.py
@@ -24,6 +24,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
 
     Attributes:
         temperature (float): temperature in Kelvin
+
     """
 
     def __init__(self, processor, temperature, sample_interval,
@@ -58,6 +59,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
                 these sublattices.
             seed (int):
                 Seed for random number generator.
+
         """
         super().__init__(processor, initial_occupancy=initial_occupancy,
                          sample_interval=sample_interval, seed=seed,
@@ -159,6 +161,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
 
         Returns:
            tuple: (minimum energy, occupation, annealing data)
+
         """
         if start_temperature < self.temperature:
             raise ValueError('End temperature is greater than start '
@@ -211,6 +214,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
 
         Returns: Flip acceptance
             bool
+
         """
         flips = self._get_flips(sublattices)
         delta_e = self.processor.compute_property_change(self._occupancy,
@@ -235,6 +239,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
                 If only considering one sublattice.
         Returns:
             tuple
+
         """
         if sublattices is None:
             sublattices = self.sublattices
@@ -248,22 +253,23 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
         if self._sublattice_overlap:
             sspace = self._active_sublatts[sublatt_name]['site_space']
             sp = list(sspace.keys())[occu1]
-            for (sublatt1, sublatt2), sp_compliment in self._sublattice_overlap[sp]:
+            for (sublatt1, sublatt2), sp_compliment in \
+                    self._sublattice_overlap[sp]:
                 if self._sublattices[sublatt1]['site_space'] == sspace:
                     swap_sublatt = sublatt2
                 elif self._sublattices[sublatt2]['site_space'] == sspace:
                     swap_sublatt = sublatt1
                 else:
                     raise RuntimeError('Something has gone real off!!!')
-                swap_species = list(self._sublattices[swap_sublatt]['site_space'].keys())
+                swap_species = \
+                    list(self._sublattices[swap_sublatt]['site_space'].keys())
                 allowed_swaps = [swap_species.index(s) for s in sp_compliment]
-                swap_options += [i for i in self._sublattices[swap_sublatt]['sites']
+                swap_options += [i for i in
+                                 self._sublattices[swap_sublatt]['sites']
                                  if self._occupancy[i] in allowed_swaps]
 
         if swap_options:
             site2 = random.choice(swap_options)
-            # Need to adjust flip if relevant bit for one species is not the same
-            # sp is species of site1; sp2 is species of site2
             sp = self.processor.allowed_species[site1][self._occupancy[site1]]
             sp2 = self.processor.allowed_species[site2][self._occupancy[site2]]
 
@@ -284,6 +290,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
 
         Returns:
             MSONable dict
+
         """
         d = {'@module': self.__class__.__module__,
              '@class': self.__class__.__name__,
@@ -313,6 +320,7 @@ class CanonicalEnsemble(BaseEnsemble, MSONable):
 
         Returns:
             CanonicalEnsemble
+            
         """
         eb = cls(BaseProcessor.from_dict(d['processor']),
                  temperature=d['temperature'],


### PR DESCRIPTION
## Summary

Some edits to fix the get_flips method.

* Updating get_flips in canonical_ensemble to ensure that the sublattices are correctly called
* Correctly account for the fact that the bits of a species can change when the species moves from one sublattice to another.
* Add blank lines so pydocstyle is happy

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
