### PR TITLE
add cutoffs property to clustersubspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Use this section to keep track of changes in the works.
 
 ### Added
+* `ClusterSubspace.cutoffs` property to obtain tight cutoffs of included
+   orbits.
 * Added properties to get orbit and ordering multiplicities of corr functions.
 [\#102](https://github.com/CederGroupHub/smol/pull/102)
 ([lbluque](https://github.com/lbluque))

--- a/smol/cofe/space/clusterspace.py
+++ b/smol/cofe/space/clusterspace.py
@@ -252,6 +252,16 @@ class ClusterSubspace(MSONable):
         return self._exp_structure
 
     @property
+    def cutoffs(self):
+        """Return dict of orbit cluster cutoffs.
+
+        These are "tight" cutoffs, as in the maximum diameter for each cluster
+        size, which is <= the input to from_cutoffs.
+        """
+        return {size: max(orbit.base_cluster.diameter for orbit in orbits)
+                for size, orbits in self._orbits.items() if size != 1}
+
+    @property
     def orbits(self):
         """Return a list of all orbits sorted by size."""
         return [orbit for _, orbits

--- a/tests/test_cofe/test_clusterspace.py
+++ b/tests/test_cofe/test_clusterspace.py
@@ -25,8 +25,9 @@ class TestClusterSubSpace(unittest.TestCase):
         self.structure = Structure(self.lattice, self.species, self.coords)
         sf = SpacegroupAnalyzer(self.structure)
         self.symops = sf.get_symmetry_operations()
+        self.cutoffs = {2: 6, 3: 5}
         self.cs = ClusterSubspace.from_cutoffs(self.structure,
-                                               cutoffs={2: 6, 3: 5},
+                                               cutoffs=self.cutoffs,
                                                basis='indicator',
                                                orthonormal=False,
                                                supercell_size='volume')
@@ -52,6 +53,10 @@ class TestClusterSubSpace(unittest.TestCase):
         orbits = [o for o in self.cs.iterorbits()]
         for o1, o2 in zip(orbits, self.cs.orbits):
             self.assertEqual(o1, o2)
+
+    def test_cutoffs(self):
+        for s, c in self.cs.cutoffs.items():
+            self.assertTrue(self.cutoffs[s] >= c)
 
     def test_orbits_by_cutoffs(self):
         # Get all of them


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary
Add `cuttoffs` property to `ClusterSubspace that holds tight cutoffs for included clusters.

## Additional dependencies introduced (if any)

<!---* List all new dependencies needed and justify why. Provide a justification why
that dependency is needed.-->

## TODO (if any)

<!---Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title, and write something about what else needs 
to be done
* Feature 1 supports A, but not B.-->


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
