### PR TITLE
get structure matching duplicates in wrangler

### DIFF
--- a/smol/cofe/wrangling/tools.py
+++ b/smol/cofe/wrangling/tools.py
@@ -41,7 +41,7 @@ def unique_corr_vector_indices(wrangler, property_key, filter_by='min',
     choose_val = np.argmin if filter_by == 'min' else np.argmax
 
     property_vector = wrangler.get_property_vector(property_key)
-    dupe_inds = wrangler.get_duplicate_corr_inds()
+    dupe_inds = wrangler.get_duplicate_corr_indices()
     indices = {inds[choose_val(property_vector[inds])]
                for inds in dupe_inds}
     duplicates = set(i for inds in dupe_inds for i in inds) - indices

--- a/tests/test_cofe/test_wrangler.py
+++ b/tests/test_cofe/test_wrangler.py
@@ -223,8 +223,22 @@ class TestStructureWrangler(unittest.TestCase):
         dup_item = deepcopy(self.sw.data_items[ind])
         self.assertWarns(UserWarning, self.sw.add_data, dup_item["structure"],
                          dup_item["properties"])
-        self.assertEqual(self.sw.get_duplicate_corr_inds(),
+        self.assertEqual(self.sw.get_duplicate_corr_indices(),
                          [[ind, self.sw.num_structures - 1]])
+
+    def test_get_matching_corr_duplicate_inds(self):
+        ind = np.random.randint(self.sw.num_structures)
+        dup_item = deepcopy(self.sw.data_items[ind])
+        ind2 = np.random.randint(self.sw.num_structures)
+        dup_item2 = deepcopy(self.sw.data_items[ind2])
+        # change the structure for this one:
+        dup_item2['structure'] = np.random.choice(
+            [s for s in self.sw.structures if s != dup_item2['structure']])
+        self.sw.append_data_items([dup_item, dup_item2])
+        expected_matches = [[ind, self.sw.num_structures - 2]]
+        self.assertTrue(all(i in matches for matches, expected in
+                            zip(self.sw.get_matching_corr_duplicate_indices(),
+                                expected_matches) for i in expected))
 
     def test_get_constant_features(self):
         ind = np.random.randint(1, self.sw.num_features)


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary
Implements `StructureWrangler.get_matching_duplicate_corr_indices` to get list of indices with duplicate correlations and that have matching structures.

* also renamed `get_duplicate_corr_inds` -> `get_duplicate_corr_indices`

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass. (except for newer pymatgen #118...)

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
