### PR TITLE
Allow streaming to file in simulated annealing

### DIFF
--- a/smol/moca/sampler/sampler.py
+++ b/smol/moca/sampler/sampler.py
@@ -313,9 +313,13 @@ class Sampler:
     ):
         """Carry out a simulated annealing procedure.
 
-        Uses the total number of temperatures given by "steps" interpolating
-        between the start and end temperature according to a cooling function.
-        The start temperature is the temperature set for the ensemble.
+        Will MC sampling for each temperature for the specified number of steps,
+        taking the last sampled configuration at each temperature as the starting
+        configuration for the next temperature.
+
+        Everything is saved to the same SampleContainer, or if streaming, saved to the
+        same file. To save each temperature in a different container, simply run
+        a similar "for loop" creating a new sampler at each temperature.
 
         Args:
             temperatures (Sequence):

--- a/smol/moca/sampler/sampler.py
+++ b/smol/moca/sampler/sampler.py
@@ -214,6 +214,7 @@ class Sampler:
         progress=False,
         stream_chunk=0,
         stream_file=None,
+        keep_last_chunk=False,
         swmr_mode=False,
     ):
         """Run an MCMC sampling simulation.
@@ -239,6 +240,10 @@ class Sampler:
             stream_file (str): optional
                 file name to use as backend. If file already exists will try
                 to append to datasets. If not given will create a new file.
+            keep_last_chunk (bool): optional
+                if True will keep the last chunk of samples in memory, but will reset
+                the sampler otherwise. This is useful if the last occupancies are
+                needed to start another run (ie for simulated annealing with streaming)
             swmr_mode (bool): optional
                 if true allows to read file from other processes. Single Writer
                 Multiple Readers.
@@ -271,7 +276,9 @@ class Sampler:
             backend = self.samples.get_backend(
                 stream_file, nsteps // thin_by, swmr_mode=swmr_mode
             )
-            self.samples.allocate(stream_chunk)
+            # allocate memory only if there is None available
+            if len(self.samples.get_occupancies()) == 0:
+                self.samples.allocate(stream_chunk)
         else:
             backend = None
             self.samples.allocate(nsteps // thin_by)
@@ -284,8 +291,10 @@ class Sampler:
                 self.samples.flush_to_backend(backend)
 
         if backend is not None:
-            self.clear_samples()
             backend.close()
+
+        if keep_last_chunk is False:
+            self.clear_samples()
 
         # A checkpoing of aux states should be saved to container here.
         # Note that to save any general "state" we will need to make sure it is
@@ -298,6 +307,9 @@ class Sampler:
         initial_occupancies=None,
         thin_by=1,
         progress=False,
+        stream_chunk=0,
+        stream_file=None,
+        swmr_mode=True,
     ):
         """Carry out a simulated annealing procedure.
 
@@ -318,6 +330,15 @@ class Sampler:
                 amount to thin by for saving samples.
             progress (bool):
                 if true will show a progress bar.
+            stream_chunk (int): optional
+                chunk of samples to stream into a file. If > 0 samples will
+                be flushed to backend file in stream_chucks
+            stream_file (str): optional
+                file name to use as backend. If file already exists will try
+                to append to datasets. If not given will create a new file.
+            swmr_mode (bool): optional
+                if true allows to read file from other processes. Single Writer
+                Multiple Readers.
         """
         if temperatures[0] < temperatures[-1]:
             raise ValueError(
@@ -332,10 +353,26 @@ class Sampler:
             initial_occupancies=initial_occupancies,
             thin_by=thin_by,
             progress=progress,
+            stream_chunk=stream_chunk,
+            stream_file=stream_file,
+            swmr_mode=swmr_mode,
+            keep_last_chunk=True,
         )
         for temperature in temperatures[1:]:
             self._kernel.temperature = temperature
-            self.run(mcmc_steps, thin_by=thin_by, progress=progress)
+            self.run(
+                mcmc_steps,
+                thin_by=thin_by,
+                progress=progress,
+                stream_chunk=stream_chunk,
+                stream_file=stream_file,
+                swmr_mode=swmr_mode,
+                keep_last_chunk=True,
+            )
+
+        # If streaming to file was done then clear samplers now.
+        if stream_chunk > 0:
+            self.clear_samples()
 
     def _reshape_occu(self, occupancies):
         """Reshape occupancies for the single walker case."""

--- a/smol/moca/sampler/sampler.py
+++ b/smol/moca/sampler/sampler.py
@@ -292,9 +292,9 @@ class Sampler:
 
         if backend is not None:
             backend.close()
-
-        if keep_last_chunk is False:
-            self.clear_samples()
+            # Only clear samples if requested.
+            if keep_last_chunk is False:
+                self.clear_samples()
 
         # A checkpoing of aux states should be saved to container here.
         # Note that to save any general "state" we will need to make sure it is

--- a/tests/test_moca/test_samplecontainer.py
+++ b/tests/test_moca/test_samplecontainer.py
@@ -39,7 +39,7 @@ def container(request, rng):
         temperature=np.zeros((0, request.param, 1)),
         accepted=np.zeros((0, request.param, 1), dtype=bool),
     )
-    sampler_container = SampleContainer(
+    sample_container = SampleContainer(
         sublattices=sublattices,
         natural_parameters=natural_parameters,
         num_energy_coefs=num_energy_coefs,
@@ -51,8 +51,8 @@ def container(request, rng):
             "seed": 0,
         },
     )
-    yield sampler_container
-    sampler_container.clear()
+    yield sample_container
+    sample_container.clear()
 
 
 @pytest.fixture
@@ -353,7 +353,6 @@ def test_flush_to_hdf5(container, fake_traces, mode, tmpdir):
     add_samples(container, fake_traces)
     file_path = os.path.join(tmpdir, "test.h5")
     chunk = len(fake_traces) // 4
-    print(chunk)
     flushed_container.allocate(chunk)
     backend = flushed_container.get_backend(file_path, len(fake_traces), swmr_mode=mode)
     start = 0
@@ -364,16 +363,42 @@ def test_flush_to_hdf5(container, fake_traces, mode, tmpdir):
         flushed_container.flush_to_backend(backend)
         start += chunk
 
-    if mode is not True:
+    if mode is False:
         backend.close()
 
     assert flushed_container._trace.occupancy.shape[0] == chunk
     assert flushed_container.num_samples == 0
     cntr = SampleContainer.from_hdf5(file_path)
+    assert cntr.num_samples == container.num_samples
+    assert cntr.total_mc_steps == container.total_mc_steps
     npt.assert_array_equal(container.get_occupancies(), cntr.get_occupancies())
     npt.assert_array_equal(container.get_energies(), cntr.get_energies())
 
     if mode is True:
         backend.close()
+
+    # now get it again, and make sure more space is allocated
+    add_samples(container, fake_traces)
+    backend = flushed_container.get_backend(file_path, len(fake_traces))
+    assert backend["trace"].attrs["nsamples"] == len(fake_traces)
+    assert len(backend["trace"]["occupancy"]) == 2 * len(fake_traces)
+
+    start = 0
+    for _ in range(4):
+        for i in range(start, start + chunk):
+            flushed_container.save_sampled_trace(fake_traces[i], thinned_by=1)
+        assert flushed_container._trace.occupancy.shape[0] == chunk
+        flushed_container.flush_to_backend(backend)
+        start += chunk
+
+    assert flushed_container._trace.occupancy.shape[0] == chunk
+    assert flushed_container.num_samples == 0
+    cntr = SampleContainer.from_hdf5(file_path)
+    assert cntr.num_samples == container.num_samples
+    assert cntr.total_mc_steps == container.total_mc_steps
+    npt.assert_array_equal(container.get_occupancies(), cntr.get_occupancies())
+    npt.assert_array_equal(container.get_energies(), cntr.get_energies())
+
+    backend.close()
 
     os.remove(file_path)


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary

* Allow streaming to hdf5 during simulated annealing runs.
* Fixed a few things with adding new samples to a closed h5 file.
* Extended some of the unit tests to catch these.

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
