### PR TITLE
fix recording traces for multiple walkers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Use this section to keep track of changes in the works.
 * Allow streaming to h5 in simulated annealing. #216 @lbluque
 ### Changed
 ### Fixed
+* Fix recording sampled traces for nwalkers > 1. #219 @lbluque
 ### Removed
 ### Deprecated
 

--- a/smol/moca/sampler/kernel.py
+++ b/smol/moca/sampler/kernel.py
@@ -298,7 +298,7 @@ class ThermalKernel(MCKernel):
             Trace
         """
         trace = super().compute_initial_trace(occupancy)
-        trace.temperature = self.trace.temperature
+        trace.temperature = np.array([self.trace.temperature])
         return trace
 
 

--- a/smol/moca/sampler/sampler.py
+++ b/smol/moca/sampler/sampler.py
@@ -197,7 +197,10 @@ class Sampler:
                         map(self._kernel.single_step, occupancies)
                     ):
                         for name, value in strace.items():
-                            setattr(trace, name, value)
+                            val = getattr(trace, name)
+                            val[i] = value
+                            # this will mess up recording values for > 1 walkers
+                            # setattr(trace, name, value)
                         if strace.accepted:
                             for name, delta_val in strace.delta_trace.items():
                                 val = getattr(trace, name)


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary

Running a sampler with walkers > 1, was not recording trace values properly. (delta_trace was correct)
This should be fixed now.

Added a test to check values match.

<!---Include a summary of major changes in bullet points:
* Feature 1
* Feature 2
* Fix 1
* Fix 2
-->


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
