### PR TITLE
Fix __str__ typo

### DIFF
--- a/smol/cofe/space/clusterspace.py
+++ b/smol/cofe/space/clusterspace.py
@@ -1287,7 +1287,7 @@ class ClusterSubspace(MSONable):
         """Convert class into pretty string for printing."""
         outs = [
             f"Basis/Orthogonal/Orthonormal : {self.basis_type}/{self.basis_orthogonal}/"
-            "{self.basis_orthonormal}",
+            f"{self.basis_orthonormal}",
             f"       Unit Cell Composition : {self.structure.composition}",
             f"            Number of Orbits : {self.num_orbits}",
             f"No. of Correlation Functions : {self.num_corr_functions}",


### PR DESCRIPTION
Fix a minor typo in ClusterSubspace.__str__

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
