### PR TITLE
add number of corr functions for sorting orbits, update max_lp and fix hierarchy tests

### DIFF
--- a/smol/cofe/space/clusterspace.py
+++ b/smol/cofe/space/clusterspace.py
@@ -1143,9 +1143,15 @@ class ClusterSubspace(MSONable):
             if new_orbit not in pt_orbits:
                 pt_orbits.append(new_orbit)
 
+        # sorted by decreasing crystallographic multiplicity and finally by increasing
+        # number of correlation functions (bit combos) -> so that higher symmetry orbits
+        # come first
         pt_orbits = sorted(
             pt_orbits,
-            key=lambda x: (np.round(x.base_cluster.diameter, 6), -x.multiplicity),
+            key=lambda x: (
+                -x.multiplicity,
+                len(x),
+            ),
         )
         return pt_orbits
 
@@ -1218,12 +1224,16 @@ class ClusterSubspace(MSONable):
                     if new_orbit not in new_orbits:
                         new_orbits.append(new_orbit)
 
+            # sorted by increasing cluster diameter, then by decreasing crystallographic
+            # multiplicity and finally by increasing number of correlation functions
+            # (bit combos) -> so that higher symmetry orbits come first
             if len(new_orbits) > 0:
                 orbits[size] = sorted(
                     new_orbits,
                     key=lambda x: (
                         np.round(x.base_cluster.diameter, 6),
                         -x.multiplicity,
+                        len(x),
                     ),
                 )
         return orbits

--- a/smol/cofe/space/clusterspace.py
+++ b/smol/cofe/space/clusterspace.py
@@ -1176,18 +1176,18 @@ class ClusterSubspace(MSONable):
             dict:
                 {size: list of Orbits within diameter cutoff}
         """
-        # Vector sum of a, b, c divided by 2.
         # diameter + max_lp gives maximum possible distance from
         # [0.5, 0.5, 0.5] prim centoid to a point in all enumerable
         # clusters. Add SITE_TOL as a numerical tolerance grace.
         orbits = {1: point_orbits}
-        max_lp = np.linalg.norm(exp_struct.lattice.matrix.sum(axis=0)) / 2
-        max_lp += SITE_TOL
-        prim_center = exp_struct.lattice.get_cartesian_coords([0.5, 0.5, 0.5])
+        centroid = exp_struct.lattice.get_cartesian_coords([0.5, 0.5, 0.5])
+        coords = exp_struct.lattice.get_cartesian_coords(exp_struct.frac_coords)
+        max_lp = max(np.sum((coords - centroid) ** 2, axis=-1) ** 0.5) + SITE_TOL
+
         for size, diameter in sorted(cutoffs.items()):
             new_orbits = []
             neighbors = exp_struct.get_sites_in_sphere(
-                prim_center, diameter + max_lp, include_index=True
+                centroid, diameter + max_lp, include_index=True
             )
             for orbit in orbits[size - 1]:
                 if orbit.base_cluster.diameter > diameter:

--- a/tests/test_cofe/test_clusterspace.py
+++ b/tests/test_cofe/test_clusterspace.py
@@ -505,7 +505,7 @@ def test_function_hierarchy_fixed(single_subspace):
     assert sorted(hierarchy[35]) == [5, 7, 10]
     assert sorted(hierarchy[56]) == [7, 8, 16]
     assert sorted(hierarchy[75]) == [7, 14, 20]
-    assert sorted(hierarchy[95]) == [9, 19]
+    assert sorted(hierarchy[95]) == [13, 19, 21]
     assert sorted(hierarchy[115]) == [13, 19, 21]
 
 

--- a/tests/test_cofe/test_clusterspace.py
+++ b/tests/test_cofe/test_clusterspace.py
@@ -503,8 +503,8 @@ def test_function_hierarchy_fixed(single_subspace):
     assert sorted(hierarchy[-1]) == [17, 21]
     assert sorted(hierarchy[15]) == []
     assert sorted(hierarchy[35]) == [5, 7, 10]
-    assert sorted(hierarchy[55]) == [6, 8, 13]
-    assert sorted(hierarchy[75]) == [7, 16, 21]
+    assert sorted(hierarchy[56]) == [7, 8, 16]
+    assert sorted(hierarchy[75]) == [7, 14, 20]
     assert sorted(hierarchy[95]) == [9, 19]
     assert sorted(hierarchy[115]) == [13, 19, 21]
 
@@ -515,7 +515,7 @@ def test_orbit_hierarchy_fixed(single_subspace):
     assert sorted(hierarchy[1]) == []  # point
     assert sorted(hierarchy[3]) == [1, 2]  # distinct site pair
     assert sorted(hierarchy[4]) == [1]  # same site pair
-    assert sorted(hierarchy[15]) == [3, 5]  # triplet
+    assert sorted(hierarchy[15]) == [3, 6]  # triplet
     assert sorted(hierarchy[-1]) == [6, 7]
 
 


### PR DESCRIPTION
- fixed hierarchy tests from fix #255 
- updated `max_lp` in cluster search to max distance to site.
- add number of corr functions for sorting orbits. This will changes the order of correlation functions!

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
