### PR TITLE
Remove size key when all orbits of a certain size have been removed

### DIFF
--- a/smol/cofe/space/clusterspace.py
+++ b/smol/cofe/space/clusterspace.py
@@ -880,6 +880,13 @@ class ClusterSubspace(MSONable):
                 orbit for orbit in orbits if orbit.id not in orbit_ids
             ]
 
+        # remove any empty keys if all orbits of a given size were removed
+        for size in list(
+            self._orbits.keys()
+        ):  # cast to list bc .keys() behaves like an iterator
+            if len(self._orbits[size]) == 0:
+                del self._orbits[size]
+
         self._assign_orbit_ids()  # Re-assign ids
         # Clear the cached supercell orbit mappings
         self._supercell_orb_inds = {}

--- a/tests/test_cofe/test_clusterspace.py
+++ b/tests/test_cofe/test_clusterspace.py
@@ -222,6 +222,12 @@ def test_remove_orbits(cluster_subspace, rng):
         subspace.corr_from_structure(structure),
     )
 
+    # remove all orbits of a certain size and make sure key is removed
+    size = rng.choice(list(subspace.orbits_by_size.keys()))
+    ids_to_remove = [o.id for o in subspace.orbits_by_size[size]]
+    subspace.remove_orbits(ids_to_remove)
+    assert size not in subspace.orbits_by_size.keys()
+
     with pytest.raises(ValueError):
         subspace.remove_orbits([-1])
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary

Remove size key in `ClusterSubspace_orbits` when all orbits of a certain size have been removed. This prevents errors when attempting to access orbits that have been removed, such as in __str__ and __repr__

<!---Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title, and write something about what else needs
to be done
* Feature 1 supports A, but not B.-->


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
