### PR TITLE
Fixes flakey failure in test_convert_formats, test_comp_space.py

### DIFF
--- a/tests/test_moca/test_comp_space.py
+++ b/tests/test_moca/test_comp_space.py
@@ -412,9 +412,9 @@ def test_convert_formats(comp_space):
         a = comp_space._A
         b = comp_space._b * supercell_size
         x_std = comp_space.get_centroid_composition(supercell_size)
-        print("basis:", comp_space.basis)
-        print("n0:", comp_space.get_supercell_base_solution(supercell_size))
-        print("x_std:", x_std)
+        # print("basis:", comp_space.basis)
+        # print("n0:", comp_space.get_supercell_base_solution(supercell_size))
+        # print("x_std:", x_std)
         n = comp_space.basis.T @ x_std + comp_space.get_supercell_base_solution(
             supercell_size
         )
@@ -487,10 +487,17 @@ def test_convert_formats(comp_space):
             )
         # Test constraints violation
         null_vec = np.random.rand(len(null_space)) * 0.01
-        if len(null_space) > 0 and not np.allclose(np.abs(null_vec), 0, atol=NUM_TOL):
-            dn = null_space.T @ null_vec
-            n_bad = n + dn
+        dn = null_space.T @ null_vec
+        n_bad = n + dn
+        if len(null_space) > 0 and not np.allclose(
+            np.abs(comp_space._A @ (n / supercell_size) - comp_space._b),
+            0,
+            atol=NUM_TOL,
+        ):
             if np.all(n_bad >= 0):
+                print("bad composition:", n_bad)
+                print("A:", comp_space._A)
+                print("b:", comp_space._b * supercell_size)
                 with pytest.raises(ValueError):
                     _ = comp_space.translate_format(
                         n_bad, supercell_size, from_format="counts", to_format="counts"


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary

<!---Include a summary of major changes in bullet points:
* Feature 1
* Feature 2
* Fix 1
* Fix 2
-->
Added conditional check in test_convert_formats to ensure that the offset from composition constraints is significant enough to override the numerical tolerance. (NUM_TOL).


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
