### PR TITLE
Use site_mappings to find refined structures in process_entry

### DIFF
--- a/smol/cofe/wrangling/wrangler.py
+++ b/smol/cofe/wrangling/wrangler.py
@@ -762,14 +762,14 @@ class StructureWrangler(MSONable):
                 entry.structure, scmatrix=supercell_matrix, site_mapping=site_mapping
             )
             refined_struct = self._subspace.refine_structure(
-                entry.structure, supercell_matrix
+                entry.structure, scmatrix=supercell_matrix, site_mapping=site_mapping
             )
 
         except StructureMatchError as s_match_error:
             if verbose:
                 warnings.warn(
                     f"Unable to match {entry.composition} with "
-                    f"properties {properties} to supercell_structure. "
+                    f"energy {entry.energy} to supercell_structure. "
                     f"Throwing out.\n Error Message: {str(s_match_error)}",
                     UserWarning,
                 )


### PR DESCRIPTION
## Summary 
Use site_mappings when searching for refined structures in entry processing, so that another structure match does not need to be carried out.

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
