### PR TITLE
small edits to follow changes in pymatgen

### DIFF
--- a/smol/cofe/space/domain.py
+++ b/smol/cofe/space/domain.py
@@ -15,7 +15,7 @@ from collections.abc import Hashable, Mapping
 
 from monty.json import MSONable
 from pymatgen.core import Composition
-from pymatgen.core.periodic_table import DummySpecie, get_el_sp
+from pymatgen.core.periodic_table import DummySpecies, get_el_sp
 from pymatgen.util.string import formula_double_format
 
 
@@ -233,11 +233,14 @@ class SiteSpace(Mapping, Hashable, MSONable):
         return cls(Composition.from_dict(d["composition"]))
 
 
-class Vacancy(DummySpecie):
+class Vacancy(DummySpecies):
     """Wrapper class around DummySpecie to treat vacancies as their own species."""
 
     def __init__(
-        self, symbol: str = "A", oxidation_state: float = 0, properties: dict = None
+        self,
+        symbol: str = "A",
+        oxidation_state: float = 0,
+        properties: dict | None = None,
     ):
         """Initialize a Vacancy.
 
@@ -250,6 +253,7 @@ class Vacancy(DummySpecie):
                 because Vac contains V, a valid Element.
             oxidation_state (float): oxidation state for Vacancy. More like
                 the charge of a point defect. Defaults to zero.
+            properties (dict): Deprecated. See pymatgen 2023.6.28 release notes.
         """
         super().__init__(
             symbol=symbol, oxidation_state=oxidation_state, properties=properties
@@ -275,8 +279,8 @@ class Vacancy(DummySpecie):
 
     def __copy__(self):
         """Copy the vacancy object."""
-        return Vacancy(self.symbol, self._oxi_state, self._properties)
+        return Vacancy(self.symbol, self._oxi_state)
 
     def __deepcopy__(self, memo):
         """Deepcopy the vacancy object."""
-        return Vacancy(self.symbol, self._oxi_state, self._properties)
+        return Vacancy(self.symbol, self._oxi_state)

--- a/smol/cofe/space/domain.py
+++ b/smol/cofe/space/domain.py
@@ -8,6 +8,8 @@ including special species such as vacancies. A site spaces makes up the domain
 of a site function and many site spaces make up the space of configurations.
 """
 
+from __future__ import annotations
+
 __author__ = "Luis Barroso-Luque, Fengyu Xie"
 
 from collections import OrderedDict
@@ -15,11 +17,11 @@ from collections.abc import Hashable, Mapping
 
 from monty.json import MSONable
 from pymatgen.core import Composition
-from pymatgen.core.periodic_table import DummySpecies, get_el_sp
+from pymatgen.core.periodic_table import DummySpecies, Element, Species, get_el_sp
 from pymatgen.util.string import formula_double_format
 
 
-def get_allowed_species(structure):
+def get_allowed_species(structure) -> list[Species]:
     """Get the allowed species for each site in a disordered structure.
 
     This will get all the allowed species for each site in a pymatgen structure.
@@ -42,7 +44,7 @@ def get_allowed_species(structure):
     return [list(site_space.keys()) for site_space in all_site_spaces]
 
 
-def get_site_spaces(structure, include_measure=False):
+def get_site_spaces(structure, include_measure=False) -> list[SiteSpace]:
     """Get site spaces for each site in a disordered structure.
 
     Method to obtain the single site spaces for the sites in a structure.
@@ -80,7 +82,7 @@ def get_site_spaces(structure, include_measure=False):
     return all_site_spaces
 
 
-def get_species(obj):
+def get_species(obj) -> Species | Element | Vacancy | DummySpecies:
     """Get specie object.
 
     Wraps pymatgen.core.periodic_table.get_el_sp to be able to catch and
@@ -228,7 +230,7 @@ class SiteSpace(Mapping, Hashable, MSONable):
         return site_space_d
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d) -> SiteSpace:
         """Create a SiteSpace from dict representation."""
         return cls(Composition.from_dict(d["composition"]))
 

--- a/tests/test_cofe/test_domain.py
+++ b/tests/test_cofe/test_domain.py
@@ -48,7 +48,7 @@ def test_get_specie_vacancy(vacancy):  # smol part
 
 
 @pytest.mark.parametrize(
-    "specie",
+    "species",
     [
         "Li",
         "Li+",
@@ -60,9 +60,9 @@ def test_get_specie_vacancy(vacancy):  # smol part
         ("Li+", "Mn2+"),
     ],
 )
-def test_get_specie_others(specie):  # pymatgen part
-    sp = get_species(specie)
-    if isinstance(specie, (list, tuple)):
+def test_get_specie_others(species):  # pymatgen part
+    sp = get_species(species)
+    if isinstance(species, (list, tuple)):
         assert all(isinstance(s, Species) or isinstance(s, Element) for s in sp)
     else:
         assert isinstance(sp, Species) or isinstance(sp, Element)


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

edit to follow deprecation of `properties` attribute in `pymatgen`. See release [v2023.6.28](https://github.com/materialsproject/pymatgen/releases/tag/v2023.6.28)

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
