### PR TITLE
Edit default openmp num threads behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,9 +15,7 @@ Use this section to keep track of changes in the works.
 # [v0.5.0](https://github.com/CederGroupHub/smol/releases/tag/v0.5.0) (2023-08-15)
 ### Added
 * `SQSGenerator.from_processors` to create a generator from a list of processors. #398 @lbluque
-### Changed
 * Periodic ground state solver (upper-bound problem formulation) #343 @qchempku2017
-### Fixed
 
 # [v0.4.1](https://github.com/CederGroupHub/smol/releases/tag/v0.4.1) (2023-07-21)
 ### Fixed

--- a/smol/utils/_openmp_helpers.pyx
+++ b/smol/utils/_openmp_helpers.pyx
@@ -75,3 +75,13 @@ cpdef _openmp_effective_numthreads(n_threads=None):
         return max(1, max_n_threads + n_threads + 1)
 
     return n_threads
+
+
+cpdef _openmp_enabled():
+    """Return true if openmp is available and enabled in build."""
+    return OPENMP_ENABLED == 1
+
+
+cpdef _openmp_get_max_threads():
+    """Return the number of threads available to the OpenMP runtime."""
+    return omp_get_max_threads()

--- a/smol/utils/_openmp_helpers.pyx
+++ b/smol/utils/_openmp_helpers.pyx
@@ -41,7 +41,6 @@ cpdef _openmp_effective_numthreads(n_threads=None):
     - For ``n_threads = None``,
       - if the ``OMP_NUM_THREADS`` environment variable is set, return
         ``openmp.omp_get_max_threads()``
-      - otherwise, default to 2 threads
       The result of ``omp_get_max_threads`` can be influenced by environment
       variable ``OMP_NUM_THREADS`` or at runtime by ``omp_set_num_threads``.
 

--- a/smol/utils/cluster/numthreads.py
+++ b/smol/utils/cluster/numthreads.py
@@ -2,6 +2,7 @@
 
 
 import os
+import warnings
 
 from .._openmp_helpers import _openmp_effective_numthreads
 
@@ -41,7 +42,13 @@ class SetNumThreads:
 
         max_threads = _openmp_effective_numthreads()
         if value > max_threads:
-            raise ValueError(f"num_threads cannot be greater than {max_threads}.")
+            warnings.warn(
+                f"num_threads cannot be greater than {max_threads}. "
+                f"Setting to {max_threads}."
+                "If you want to use more threads, make sure openmp is enabled and set"
+                "the OMP_NUM_THREADS environment variable accordingly."
+            )
+            value = max_threads
 
         obj = getattr(instance, self._obj_name)
         num_threads = _openmp_effective_numthreads(value)

--- a/smol/utils/cluster/numthreads.py
+++ b/smol/utils/cluster/numthreads.py
@@ -1,9 +1,14 @@
 """Simple mixin class that has an attributed/method that runs in parallel."""
 
 
+import os
+
 from .._openmp_helpers import _openmp_effective_numthreads
 
-DEFAULT_NUM_THREADS = _openmp_effective_numthreads(n_threads=2)
+if os.getenv("OMP_NUM_THREADS") is not None:
+    DEFAULT_NUM_THREADS = _openmp_effective_numthreads()
+else:
+    DEFAULT_NUM_THREADS = _openmp_effective_numthreads(n_threads=2)
 
 
 class SetNumThreads:

--- a/tests/test_moca/test_processor.py
+++ b/tests/test_moca/test_processor.py
@@ -453,5 +453,6 @@ def test_set_threads(single_subspace):
     assert ceproc.num_threads == _openmp_effective_numthreads(n_threads=-1)
 
     # assert setting more complains
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         ceproc.num_threads = _openmp_effective_numthreads() + 1
+        assert ceproc.num_threads == _openmp_effective_numthreads()

--- a/tests/test_utils/test_numthreads.py
+++ b/tests/test_utils/test_numthreads.py
@@ -1,0 +1,77 @@
+import os
+from importlib import reload
+
+import pytest
+
+from smol.utils import _openmp_helpers
+from smol.utils.cluster import numthreads
+
+
+class Dummy:
+    num_threads = numthreads.SetNumThreads("_multithreaded_dummy")
+
+    def __init__(self, num_threads=None):
+        self._multithreaded_dummy = MultithreadedDummy()
+        self.num_threads = num_threads
+
+
+class MultithreadedDummy:
+    def __init__(self):
+        self.num_threads = 1
+
+
+def test_openmp_numthreads_env_set(monkeypatch):
+    # this is not completely working, it seems that 4 is the default number of threads
+    monkeypatch.setenv("OMP_NUM_THREADS", "4")
+
+    reload(_openmp_helpers)
+    reload(numthreads)
+    dummy = Dummy()
+
+    if _openmp_helpers._openmp_enabled():
+        assert _openmp_helpers._openmp_effective_numthreads() == 4
+        assert _openmp_helpers._openmp_effective_numthreads(2) == 2
+        assert dummy.num_threads == 4
+        assert Dummy(num_threads=1).num_threads == 1
+        with pytest.warns(UserWarning):
+            dummy.num_threads = 5
+        assert dummy.num_threads == 4
+    else:
+        assert _openmp_helpers._openmp_effective_numthreads(2) == 1
+        assert _openmp_helpers._openmp_effective_numthreads() == 1
+        assert _openmp_helpers._openmp_effective_numthreads(-1) == 1
+        assert dummy.num_threads == 1
+
+
+def test_openmp_numthreads_no_set(monkeypatch):
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    reload(_openmp_helpers)
+    reload(numthreads)
+    dummy = Dummy()
+
+    if _openmp_helpers._openmp_enabled():
+        assert _openmp_helpers._openmp_effective_numthreads(2) == 2
+        assert _openmp_helpers._openmp_effective_numthreads() == min(
+            os.cpu_count(), _openmp_helpers._openmp_get_max_threads()
+        )
+        assert _openmp_helpers._openmp_effective_numthreads(-1) == min(
+            os.cpu_count(), _openmp_helpers._openmp_get_max_threads()
+        )
+        assert (
+            _openmp_helpers._openmp_effective_numthreads(-2)
+            == min(os.cpu_count(), _openmp_helpers._openmp_get_max_threads()) - 1
+        )
+        assert dummy.num_threads == 2
+        assert Dummy(num_threads=1).num_threads == 1
+        with pytest.warns(UserWarning):
+            dummy.num_threads = (
+                min(os.cpu_count(), _openmp_helpers._openmp_get_max_threads()) + 1
+            )
+        assert dummy.num_threads == min(
+            os.cpu_count(), _openmp_helpers._openmp_get_max_threads()
+        )
+    else:
+        assert _openmp_helpers._openmp_effective_numthreads(2) == 1
+        assert _openmp_helpers._openmp_effective_numthreads() == 1
+        assert _openmp_helpers._openmp_effective_numthreads(-1) == 1
+        assert dummy.num_threads == 1

--- a/tests/test_utils/test_numthreads.py
+++ b/tests/test_utils/test_numthreads.py
@@ -1,5 +1,4 @@
 import os
-from importlib import reload
 
 import pytest
 
@@ -20,33 +19,8 @@ class MultithreadedDummy:
         self.num_threads = 1
 
 
-def test_openmp_numthreads_env_set(monkeypatch):
-    # this is not completely working, it seems that 4 is the default number of threads
-    monkeypatch.setenv("OMP_NUM_THREADS", "4")
-
-    reload(_openmp_helpers)
-    reload(numthreads)
-    dummy = Dummy()
-
-    if _openmp_helpers._openmp_enabled():
-        assert _openmp_helpers._openmp_effective_numthreads() == 4
-        assert _openmp_helpers._openmp_effective_numthreads(2) == 2
-        assert dummy.num_threads == 4
-        assert Dummy(num_threads=1).num_threads == 1
-        with pytest.warns(UserWarning):
-            dummy.num_threads = 5
-        assert dummy.num_threads == 4
-    else:
-        assert _openmp_helpers._openmp_effective_numthreads(2) == 1
-        assert _openmp_helpers._openmp_effective_numthreads() == 1
-        assert _openmp_helpers._openmp_effective_numthreads(-1) == 1
-        assert dummy.num_threads == 1
-
-
-def test_openmp_numthreads_no_set(monkeypatch):
+def test_openmp_numthreads(monkeypatch):
     monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
-    reload(_openmp_helpers)
-    reload(numthreads)
     dummy = Dummy()
 
     if _openmp_helpers._openmp_enabled():


### PR DESCRIPTION
<!---Edit the following according to your PR.-->

## Summary
Edits the default setting of the number of openmp threads according to the conversation in #403 
* If `OMP_NUM_THREADS` is set, then that value is used as default.
* If the number of set threads is > than max available a warning is raised instead of an error, and the number of threads is set to the max available.

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
