### PR TITLE
Downgrade artifact from v4 to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: wheelhouse/*.whl
 
@@ -94,7 +94,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: wheelhouse/*.whl
 
@@ -110,6 +110,6 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.event.inputs.release-pypi == 'true'
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
To handle errors in pip builds that arise from artifact v4, documented here: https://github.com/actions/upload-artifact/issues/478

## Summary

Major changes:

- Downgrade artifact from v4 to v3 in the build and release github workflows

## Todos

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [x] All existing tests pass.
- [x] Tests have been added for any new features/fixes.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

