### PR TITLE
Upload coverage only on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           pytest --cov=smol --splits 8 --group ${{ matrix.split }} --durations-path tests/.test_durations tests
 
       - name: Upload coverage
-        if: ${{ matrix.config.python == '3.12' }}
+        if: ${{ matrix.config.python == '3.12' && github.ref == 'refs/heads/main'}}
         uses: actions/upload-artifact@v4
         with:
           include-hidden-files: true
@@ -59,6 +59,7 @@ jobs:
           if-no-files-found: error
 
   coverage:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           pytest --cov=smol --splits 8 --group ${{ matrix.split }} --durations-path tests/.test_durations tests
 
       - name: Upload coverage
-        if: ${{ matrix.config.python == '3.12' && github.event_name == 'push' }}
+        if: ${{ matrix.config.python == '3.12' }}
         uses: actions/upload-artifact@v4
         with:
           include-hidden-files: true


### PR DESCRIPTION
Upload coverage only on ref main.

## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [X] All existing tests pass.
- [X] Tests have been added for any new features/fixes.
- [X] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
